### PR TITLE
:bug: fix: Properly initialize a new scanner on Android

### DIFF
--- a/android/src/main/kotlin/cloud/infiniteloop/simpleblue/simpleblue/SimplebluePlugin.kt
+++ b/android/src/main/kotlin/cloud/infiniteloop/simpleblue/simpleblue/SimplebluePlugin.kt
@@ -272,7 +272,7 @@ class SimplebluePlugin : FlutterPlugin,
                 }
                 BluetoothAdapter.ACTION_DISCOVERY_STARTED -> {
                     Log.d(TAG, "Bluetooth Discovery started")
-
+                    devices.clear()
                     eventSink?.success(
                         mapOf(
                             "type" to "scanningState",


### PR DESCRIPTION
When running the device scanner for the second time, an error occurred because the previously listed devices were not cleared. Added devices.clear() to ensure the device list is reset before running a new scan.